### PR TITLE
changed to just one data source

### DIFF
--- a/ijic_config_updates.json
+++ b/ijic_config_updates.json
@@ -1,7 +1,4 @@
-addDataSource IJIC-PANAMA
-addDataSource IJIC-PARADISE
-addDataSource IJIC-BAHAMAS
-addDataSource IJIC-OFFSHORE
+addDataSource IJIC
 
 addEntityType PERSON
 addEntityType ORGANIZATION


### PR DESCRIPTION
Changed IJIC-PANAMA, IJIC_PARADISE, IJIC_BAHAMAS, and IJIC_OFFSHORE to just one data source called IJIC.

This makes reports of cross matches much cleaner.